### PR TITLE
Fix hex logo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,7 +22,7 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 
 [params]
     description = "Blog for the R-hub project of the R Consortium, easing the R package development process."
-
+    customCSS = ["css/rhub.css"]
     # options for highlight.js (version, additional languages, and theme)
     highlightjsVersion = "9.12.0"
     highlightjsCDN = "//cdnjs.cloudflare.com/ajax/libs"

--- a/static/css/rhub.css
+++ b/static/css/rhub.css
@@ -1,0 +1,6 @@
+.nav-logo img {
+  display: block;
+  max-height: 50px;
+  width: auto;
+  border-radius: 0px;
+}


### PR DESCRIPTION
The logo for the Lithium theme has a border radius in the CSS that cuts off the corners of a hex logo- overrode with `static/css/rhub.css` and updated `config.toml` to reference the custom CSS file (as we did here: https://github.com/rbind/blogdown-demo/pull/16).

<img width="1399" alt="Screen Shot 2019-05-14 at 6 18 30 AM" src="https://user-images.githubusercontent.com/12160301/57701126-eb496e80-7620-11e9-8cc5-71c7de8075ac.png">
