### PR TITLE
Add thin spaces between author names

### DIFF
--- a/layouts/partials/get-authors.html
+++ b/layouts/partials/get-authors.html
@@ -1,7 +1,7 @@
 <!-- List authors with proper list formatting -->
 <a href="/authors" title="Authors" alt="/authors"><i class="fa fa-user mr-2"></i></a>
 {{ range $index, $value := .Params.authors }}
-    {{ if $index }}, {{ end }}
+    {{ if $index }},&thinsp;{{ end }}
     <a href='{{ "/authors/" | relLangURL }}{{ . | urlize }}'>{{ title ($value | humanize) }}</a>
 {{ end }}
 <!---->


### PR DESCRIPTION
Hello :wave:
I've noticed that the list of author names of multi-authors blog posts doesn't show up nicely:

![image](https://user-images.githubusercontent.com/5593751/171999933-143b6706-355d-4fc0-8e55-f70424410152.png)

It seems that the space included doesn't work.
So I'm proposing to add an explicit thin space after the comma so that it looks nicer! I wanted to add a regular space with &nbsp; but it will make it non-breakable so if there is a very long author list it can still be wrappable.
